### PR TITLE
Logs configuration + fail fast on missing cache

### DIFF
--- a/cron/cache_reset.sh
+++ b/cron/cache_reset.sh
@@ -44,13 +44,14 @@ if [ -d "$war_dir/WEB-INF" ]
  then
     cd $war_dir'/WEB-INF'
     path=$(pwd)
-    java_cmd="java -classpath \"./lib/\*:./classes/.\" fr.lirmm.fairness.assessment.CacheSaverCMD"
+    logging_config="./classes/logging.properties"
+    java_cmd="java -Djava.util.logging.config.file=$logging_config -classpath \"./lib/\*:./classes/.\" fr.lirmm.fairness.assessment.CacheSaverCMD"
     echo "[+] Running '$java_cmd' in '$path' "
      if [ ! -d $log_dir_path ]; then
        mkdir -p /var/log/tomcat/log/FAIR_CACHE
      fi
     touch $log_file_name
-    java -classpath "lib/*:./classes/." fr.lirmm.fairness.assessment.CacheSaverCMD  2>&1 | tee $log_file_name
+    java -Djava.util.logging.config.file="$logging_config" -classpath "lib/*:./classes/." fr.lirmm.fairness.assessment.CacheSaverCMD 2>&1 | tee $log_file_name
 
 else
   echo "the war directory of FAIR assessment is not found in : $war_dir"

--- a/src/main/java/fr/lirmm/fairness/assessment/CacheSaverCMD.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/CacheSaverCMD.java
@@ -5,8 +5,12 @@ import fr.lirmm.fairness.assessment.models.PortalInstance;
 import fr.lirmm.fairness.assessment.utils.ResultCache;
 
 import java.io.IOException;
+import java.util.logging.Logger;
 
 public class CacheSaverCMD {
+
+    private static final Logger LOGGER = Logger.getLogger(CacheSaverCMD.class.getName());
+
     public static void main(String[] args) throws IOException {
         ResultCache resultCache = new ResultCache();
         if(args.length == 0){
@@ -14,8 +18,7 @@ public class CacheSaverCMD {
         }
 
         for (String portal : args) {
-            System.out.println("Cache saver for : " + portal);
-            System.out.println();
+            LOGGER.info("Cache saver for : " + portal);
             resultCache.flush(portal);
             resultCache.save(PortalInstance.getFromConfiguration(Configuration.getInstance() , portal, true));
         }

--- a/src/main/java/fr/lirmm/fairness/assessment/FairServlet.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/FairServlet.java
@@ -1,6 +1,7 @@
 package fr.lirmm.fairness.assessment;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
@@ -27,6 +28,8 @@ import org.json.JSONException;
  */
 public class FairServlet extends HttpServlet {
 
+    private static final Logger LOGGER = Logger.getLogger(FairServlet.class.getName());
+
     private static final long serialVersionUID = -2749023988723161904L;
     private final ResultCache resultCache = new ResultCache();
 
@@ -43,10 +46,10 @@ public class FairServlet extends HttpServlet {
             JsonObject ontologies = null;
             portalInstance = requestController.getPortalInstance();
 
-            Logger.getAnonymousLogger().info("USE THE PORTAL : " + portalInstance.getName() + "; url= " + portalInstance.getUrl() + "; apikey= " + portalInstance.getApikey());
+            LOGGER.info("USE THE PORTAL : " + portalInstance.getName() + "; url= " + portalInstance.getUrl() + "; apikey= " + portalInstance.getApikey());
             List<String> ontologyAcronymsToEvaluate = requestController.getOntologies();
 
-            Logger.getAnonymousLogger().info("START EVALUATION OF : " + ontologyAcronymsToEvaluate.size() + " ONTOLOGIES FROM " + portalInstance.getName().toUpperCase(Locale.ROOT));
+            LOGGER.info("START EVALUATION OF : " + ontologyAcronymsToEvaluate.size() + " ONTOLOGIES FROM " + portalInstance.getName().toUpperCase(Locale.ROOT));
             if (requestController.isCacheDisabled()) {
                 if (ontologyAcronymsToEvaluate.size() > 0) {
                     Iterator<String> it = ontologyAcronymsToEvaluate.iterator();
@@ -56,7 +59,7 @@ public class FairServlet extends HttpServlet {
                         String acronym = it.next();
                         JsonElement fair = evaluateOntology(acronym, portalInstance);
                         ontologies.add(acronym, fair);
-                        Logger.getAnonymousLogger().info("(" + (i++) + "/" + ontologyAcronymsToEvaluate.size() + ") > Ontology " + acronym + " evaluated in " + fair.getAsJsonObject().get("executionTime").getAsString() + " s ");
+                        LOGGER.info("(" + (i++) + "/" + ontologyAcronymsToEvaluate.size() + ") > Ontology " + acronym + " evaluated in " + fair.getAsJsonObject().get("executionTime").getAsString() + " s ");
                     }
                 }
             } else {
@@ -82,14 +85,14 @@ public class FairServlet extends HttpServlet {
 
 
             responseController.respond(true, requestController.getRequestURI(req) , startTime ,""  , requestController);
-            Logger.getAnonymousLogger().info("EVALUATION  ENDED WITH STATUS : " + responseController.getResponse().get("status") );
+            LOGGER.info("EVALUATION  ENDED WITH STATUS : " + responseController.getResponse().get("status") );
 
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Evaluation request failed", e);
             try {
                 responseController.respond(false, requestController.getRequestURI(req) , startTime ,e.getMessage() ,requestController);
             } catch (Exception ex) {
-                ex.printStackTrace();
+                LOGGER.log(Level.SEVERE, "Failed to write error response", ex);
             }
         }
 

--- a/src/main/java/fr/lirmm/fairness/assessment/controllers/ResponseController.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/controllers/ResponseController.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 
 public class ResponseController {
 
+    private static final Logger LOGGER = Logger.getLogger(ResponseController.class.getName());
 
     private final HttpServletResponse servletResponse;
     private final JsonObject response;
@@ -62,7 +63,7 @@ public class ResponseController {
             out.print(this.response.toString());
             out.flush();
         } catch (IOException e) {
-            Logger.getAnonymousLogger().severe("JSON RESPONSE ERROR : " + e.getMessage());
+            LOGGER.severe("JSON RESPONSE ERROR : " + e.getMessage());
         }
 
     }

--- a/src/main/java/fr/lirmm/fairness/assessment/models/Configuration.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/models/Configuration.java
@@ -4,8 +4,12 @@ import com.google.gson.Gson;
 
 import java.io.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Configuration {
+
+	private static final Logger LOGGER = Logger.getLogger(Configuration.class.getName());
 
 	public static final String PROPERTIES_CONFIG_FILE_PATH = "config/common/properties.config.json";
 	public static final String FAIR_CONFIG_FILE_PATH = "config/common/questions.config.json";
@@ -65,7 +69,7 @@ public class Configuration {
 					throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
 				}
 			} catch (Exception e) {
-				System.out.println("Exception: " + e);
+				LOGGER.log(Level.SEVERE, "Failed to load properties for scope " + configScope, e);
 				properties = null;
 			} finally {
 				if(inputStream != null) {

--- a/src/main/java/fr/lirmm/fairness/assessment/models/Ontology.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/models/Ontology.java
@@ -3,6 +3,8 @@ package fr.lirmm.fairness.assessment.models;
 import java.io.IOException;
 import java.net.URL;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -11,6 +13,8 @@ import org.json.JSONException;
 import fr.lirmm.fairness.assessment.utils.OntologyRestApi;
 
 public class Ontology {
+
+	private static final Logger LOGGER = Logger.getLogger(Ontology.class.getName());
 
 	private final static String FORMAT_APPLICATION_JSON = "application/json";
 	private final static String FORMAT_APPLICATION_XML = "application/xml"; 
@@ -46,7 +50,7 @@ public class Ontology {
 								this.addSubmissionPropertyValue(property);
 							}
 						} catch (JSONException | IOException e) {
-							e.printStackTrace();
+							LOGGER.log(Level.SEVERE, "Failed to load submission property " + property.getLabel(), e);
 						}
 
 					break;
@@ -58,14 +62,14 @@ public class Ontology {
 							this.addOntologyPropertyValue(property);
 						}
 					} catch (JSONException | IOException e) {
-						e.printStackTrace();
+						LOGGER.log(Level.SEVERE, "Failed to load ontology property " + property.getLabel(), e);
 					}
 					break;
 				case "metrics":
 					try {
 						this.addMetricsPropertyValue(property);
 					} catch (Exception e) {
-						e.printStackTrace();
+						LOGGER.log(Level.SEVERE, "Failed to load metrics property " + property.getLabel(), e);
 					}
 					break;
 				case "link":
@@ -76,7 +80,7 @@ public class Ontology {
 							this.addOntologyLinkPropertyValue(property);
 						}
 					} catch (Exception e) {
-						e.printStackTrace();
+						LOGGER.log(Level.SEVERE, "Failed to load link property " + property.getLabel(), e);
 					}
 			}
 		});

--- a/src/main/java/fr/lirmm/fairness/assessment/principles/AbstractPrinciple.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/principles/AbstractPrinciple.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import fr.lirmm.fairness.assessment.models.results.QuestionResult;
@@ -16,9 +18,11 @@ import fr.lirmm.fairness.assessment.principles.criterion.AbstractPrincipleCriter
 
 
 public abstract class AbstractPrinciple extends AbstractScoredEntity implements Evaluable,Serializable {
-	
+
+	private static final Logger LOGGER = Logger.getLogger(AbstractPrinciple.class.getName());
+
 	private static final long serialVersionUID = -4625119538425966086L;
-	
+
 	private List<AbstractPrincipleCriterion> principleCriteria = null;
 
 	protected AbstractPrinciple() {
@@ -36,18 +40,20 @@ public abstract class AbstractPrinciple extends AbstractScoredEntity implements 
 		this.weights = new ArrayList<>(this.principleCriteria.size());
 		while(iterator.hasNext()) {
 			try {
-				System.out.println("\n");
 				AbstractPrincipleCriterion criterion = iterator.next();
 				criterion.evaluate(ontology);
 				this.scores.add(criterion.getTotalScore());
 				this.weights.add(criterion.getTotalScoreWeight());
-				System.out.println("> " + criterion.getClass().getSimpleName() + " points : " + criterion.getScores());
-				System.out.println("> Total score for " + criterion.getClass().getSimpleName() + " : " + criterion.getTotalScore());
-				System.out.println("> Explanations : " + criterion.getResults().stream().map(x-> ((QuestionResult)x).getExplanation()).collect(Collectors.toList()));
-				System.out.println("> Normalized total score for " + criterion.getClass().getSimpleName() + " : " + criterion.getNormalizedTotalScore());
+				if (LOGGER.isLoggable(Level.FINE)) {
+					String name = criterion.getClass().getSimpleName();
+					LOGGER.fine("> " + name + " points : " + criterion.getScores());
+					LOGGER.fine("> Total score for " + name + " : " + criterion.getTotalScore());
+					LOGGER.fine("> Explanations : " + criterion.getResults().stream().map(x-> ((QuestionResult)x).getExplanation()).collect(Collectors.toList()));
+					LOGGER.fine("> Normalized total score for " + name + " : " + criterion.getNormalizedTotalScore());
+				}
 			}
 			catch(Exception iae) {
-				iae.printStackTrace();
+				LOGGER.log(Level.SEVERE, "Criterion evaluation failed", iae);
 			}
 		}
 	}
@@ -81,7 +87,7 @@ public abstract class AbstractPrinciple extends AbstractScoredEntity implements 
 				this.principleCriteria.add(subCriteriaClassesClass.getDeclaredConstructor().newInstance());
 			}
 			catch(Exception e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "Failed to instantiate criterion " + subCriteriaClassesClass.getName(), e);
 			}
 		}
 	}

--- a/src/main/java/fr/lirmm/fairness/assessment/principles/criterion/AbstractPrincipleCriterion.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/principles/criterion/AbstractPrincipleCriterion.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
@@ -20,7 +22,9 @@ import fr.lirmm.fairness.assessment.models.Ontology;
 import fr.lirmm.fairness.assessment.principles.Evaluable;
 
 public abstract class AbstractPrincipleCriterion extends AbstractScoredEntity implements Evaluable, Serializable {
-	
+
+	private static final Logger LOGGER = Logger.getLogger(AbstractPrincipleCriterion.class.getName());
+
 	private static final long serialVersionUID = -5519124612489307590L;
 	protected List<AbstractCriterionQuestion> questions = null;
 	private Double maxCredits = 0.0;
@@ -36,7 +40,9 @@ public abstract class AbstractPrincipleCriterion extends AbstractScoredEntity im
 	@Override
 	public final void evaluate(Ontology ontology) throws JSONException, IOException {
 		this.results = new ArrayList<>();
-		System.out.println("> Evaluating '" + this.getClass().getSimpleName() + "' of ontology '" + ontology.getAcronym() + "' on repository '" + ontology.getPortalInstance().getName() + "' (" + ontology.getPortalInstance().getUrl() + "?apikey=" + ontology.getPortalInstance().getApikey() + ").");
+		if (LOGGER.isLoggable(Level.FINE)) {
+			LOGGER.fine("> Evaluating '" + this.getClass().getSimpleName() + "' of ontology '" + ontology.getAcronym() + "' on repository '" + ontology.getPortalInstance().getName() + "' (" + ontology.getPortalInstance().getUrl() + "?apikey=" + ontology.getPortalInstance().getApikey() + ").");
+		}
 		this.doEvaluation(ontology);
 		this.scores = this.results.stream().map(x -> x.getScore()).collect(Collectors.toList());
 		this.weights = this.questions.stream().map(x -> x.getMaxPoint().getScore()).collect(Collectors.toList());;
@@ -87,7 +93,7 @@ public abstract class AbstractPrincipleCriterion extends AbstractScoredEntity im
 			fillQuestions(criterionList);
 
 		} catch(Exception ioe) {
-			ioe.printStackTrace();
+			LOGGER.log(Level.SEVERE, "Failed to load criterion properties for " + this.getClass().getSimpleName(), ioe);
 		}
 	}
 

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/OntologyRestApi.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/OntologyRestApi.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.json.JSONArray;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class OntologyRestApi {
 
+	private static final Logger LOGGER = Logger.getLogger(OntologyRestApi.class.getName());
 
 	private String ontologyMetadata = null;
 	private ObjectMapper mapper = null;
@@ -52,7 +54,7 @@ public class OntologyRestApi {
 				}
 			}
 		} catch (Exception e){
-			Logger.getAnonymousLogger().info(e.getMessage());
+			LOGGER.fine(e.getMessage());
 		}
 
 
@@ -68,7 +70,7 @@ public class OntologyRestApi {
 		try{
 			metadataValue = objMappings.getJSONObject("ontology").getString(metadataname);
 		}catch (Exception e){
-			Logger.getAnonymousLogger().info(e.getMessage());
+			LOGGER.fine(e.getMessage());
 		}
 
 		return (metadataValue);
@@ -82,7 +84,7 @@ public class OntologyRestApi {
 		try{
 			metadataValue = objMappings.getJSONObject("metrics").getString(metadataname);
 		}catch (Exception e){
-			Logger.getAnonymousLogger().info(metadataname + " " + e.getMessage());
+			LOGGER.fine(metadataname + " " + e.getMessage());
 		}
 
 		return (metadataValue);
@@ -96,7 +98,7 @@ public class OntologyRestApi {
 		try{
 			metadataValue = objMappings.getString(metadataname);
 		} catch (Exception e){
-			Logger.getAnonymousLogger().info(e.getMessage());
+			LOGGER.fine(e.getMessage());
 		}
 
 		return (metadataValue);
@@ -124,7 +126,7 @@ public class OntologyRestApi {
 		try {
 			root = mapper.readTree(json);
 		} catch (JsonProcessingException e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "Failed to parse JSON metadata", e);
 		}
 		return root;
 	}

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
@@ -11,8 +11,12 @@ import java.io.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ResultCache {
+
+    private static final Logger LOGGER = Logger.getLogger(ResultCache.class.getName());
 
     public static String FILE_SAVE_NAME = "save.json";
 
@@ -45,14 +49,14 @@ public class ResultCache {
             getFileSaveName(portal);
             resultCache.store(output.toString() , FILE_SAVE_NAME);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Failed to save cache for " + portalInstance.getName(), e);
         }
     }
 
     public JsonObject read(PortalInstance portalInstance) throws IOException {
         String portal = portalInstance.getName();
         if (!this.isSaved(portal)){
-            System.out.println(portal+" save files not exist ");
+            LOGGER.info(portal + " save files not exist");
             this.save(portalInstance);
         }
         Gson gson = new GsonBuilder().create();
@@ -87,7 +91,7 @@ public class ResultCache {
                     file.close();
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.log(Level.SEVERE, "Failed to close cache writer", e);
             }
         }
     }
@@ -120,7 +124,7 @@ public class ResultCache {
         try {
             FILE_SAVE_NAME = Configuration.getInstance().getPortalProperties(portal.toLowerCase(Locale.ROOT)).getProperty("cacheFilePath");
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Failed to read cacheFilePath for portal " + portal, e);
         }
         return FILE_SAVE_NAME;
     }

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
@@ -60,8 +60,7 @@ public class ResultCache {
     public JsonObject read(PortalInstance portalInstance) throws IOException {
         String portal = portalInstance.getName();
         if (!this.isSaved(portal)){
-            LOGGER.info(portal + " save files not exist");
-            this.save(portalInstance);
+            throw new IOException("Cache not yet generated for portal '" + portal + "'. Run cache_reset.sh or wait for the next cron run.");
         }
         Gson gson = new GsonBuilder().create();
 

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
@@ -33,15 +33,19 @@ public class ResultCache {
 
 
             Iterator<String> it = allOntologyAcronyms.iterator();
-
+            int total = allOntologyAcronyms.size();
+            int i = 1;
             while (it.hasNext()) {
+                String acronym = it.next();
+                long start = System.currentTimeMillis();
 
                 Fair fair = new Fair();
-                fair.evaluate(new Ontology(it.next(), portalInstance));
+                fair.evaluate(new Ontology(acronym, portalInstance));
 
                 JsonObject tmp = new FairJsonConverter(fair).toJson();
                 tmp.entrySet().forEach(x -> jsonObjects.add(x.getKey(), x.getValue()));
 
+                LOGGER.info("(" + (i++) + "/" + total + ") > Ontology " + acronym + " evaluated in " + ((System.currentTimeMillis() - start) / 1000.0) + " s");
             }
 
             output.add("ontologies", gson.toJsonTree(jsonObjects));

--- a/src/main/resources/config/portals/agroportal/config.env.properties.example
+++ b/src/main/resources/config/portals/agroportal/config.env.properties.example
@@ -1,5 +1,0 @@
-name=AgroPortal
-url=http://data.agroportal.lirmm.fr
-apikey=<your_api_key>
-cacheFilePath=<your_path>
-cacheEnabled=true

--- a/src/main/resources/config/portals/bioportal/config.env.properties.example
+++ b/src/main/resources/config/portals/bioportal/config.env.properties.example
@@ -1,5 +1,0 @@
-name=BioPortal
-url=http://data.bioportal.lirmm.fr
-apikey=<your_api_key>
-cacheFilePath=<your_path>
-cacheEnabled=true

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,10 @@
+handlers = java.util.logging.ConsoleHandler
+
+.level = INFO
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s %3$s - %5$s%6$s%n
+
+fr.lirmm.fairness.assessment.level = INFO


### PR DESCRIPTION
## Summary
- Making the logs configurable using `Java.util.logging.Level`, by default set to `INFO`. 

 | Level   | Use for                                               |
  |---------|-------------------------------------------------------|
  | SEVERE  | Failures / errors that need attention                 |
  | WARNING | Suspicious situations, recoverable problems           |
  | INFO    | High-level lifecycle messages (default visible level) |
  | CONFIG  | Static configuration info at startup                  |
  | FINE    | Tracing / debug detail                                |

- Stop regenerating the cache inline on cache-enabled servlet requests when `save.json` is missing — throw an `IOException` instead. Cache generation is the cron's job; failing fast prevents request threads from piling up running the same cache generation in parallel.

now the logs on `INFO` level look like this:

```
2026-04-28 08:36:42 INFO fr.lirmm.fairness.assessment.CacheSaverCMD - Cache saver for : agroportal
2026-04-28 08:36:43 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (1/332) > Ontology GFTL evaluated in 0.809 s
2026-04-28 08:36:44 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (2/332) > Ontology OEEV-SUNAGRI evaluated in 0.84 s
2026-04-28 08:36:46 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (3/332) > Ontology AAB evaluated in 1.629 s
2026-04-28 08:36:46 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (4/332) > Ontology OESO-SIXTINE evaluated in 0.646 s
2026-04-28 08:36:47 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (5/332) > Ontology OESO-SIXTINE-V evaluated in 0.543 s
2026-04-28 08:36:48 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (6/332) > Ontology CO_121 evaluated in 0.604 s
2026-04-28 08:36:48 INFO fr.lirmm.fairness.assessment.utils.ResultCache - (7/332) > Ontology FOODIE evaluated in 0.641 s
``` 