### PR TITLE
Safely publish caches, bound HTTP requests, and redact response metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ mvn clean package
 ```
 ### Cache and HTTP safety
 
-Cache refreshes are generated completely before publication. A candidate is written and validated in the cache directory, then atomically replaces the current cache only when its non-empty ontology count exactly matches the source catalogue count. Evaluation, validation, write, or atomic-move failures preserve the previous cache. Filesystems that do not support atomic moves refuse the refresh rather than falling back to a non-atomic replacement.
+Cache refreshes are generated completely before publication. A candidate is written and validated in the cache directory, then atomically replaces the current cache only when its non-empty ontology count exactly matches the source catalogue count. Evaluation, validation, write, or atomic-move failures preserve the previous cache. Filesystems that do not support atomic moves refuse the refresh rather than falling back to a non-atomic replacement. On POSIX filesystems, replacement copies and verifies an existing cache's owner, group, and permissions before publication, refusing the refresh if any attribute cannot be preserved; a new cache starts with the prior `0666` readable default filtered by the process umask. Non-POSIX filesystems retain their provider's default permissions.
 
 Check a configured portal's cache with:
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ O'FAIRe returns a JSON with the following skeleton :
     }
   },
   "status": { // operation meta-data
-    "request": "http://service.agroportal.lirmm.fr?portal=stageportal&ontologies=FCU", // original request
+    "request": "http://service.agroportal.lirmm.fr/ofaire", // query parameters are omitted
     "success": true,
     "executionTime": 959,
     "endpoint": "http://data.agroportal.lirmm.fr",
@@ -198,6 +198,31 @@ Portal configuration is required by the *portal* parameter. File is available in
 ```bash
 mvn clean package
 ```
+### Cache and HTTP safety
+
+Cache refreshes are generated completely before publication. A candidate is written and validated in the cache directory, then atomically replaces the current cache only when its non-empty ontology count exactly matches the source catalogue count. Evaluation, validation, write, or atomic-move failures preserve the previous cache. Filesystems that do not support atomic moves refuse the refresh rather than falling back to a non-atomic replacement.
+
+Check a configured portal's cache with:
+
+```bash
+CacheHealthCMD <portal>
+```
+
+Invoke the command class `fr.lirmm.fairness.assessment.CacheHealthCMD` with the application's normal runtime classpath.
+
+`CacheHealthCMD` exits `0` only when exactly one configured portal is supplied and its cache contains a non-empty `ontologies` JSON object. It exits `1` for bad arguments, unknown portals, missing files, malformed JSON, wrong shapes, and empty caches.
+
+Outbound requests use positive JVM timeout properties. Defaults are:
+
+Property | Default
+------------ | -------------
+`fairness.http.connectTimeoutMillis` | 10000
+`fairness.http.readTimeoutMillis` | 30000
+`fairness.urlCheck.connectTimeoutMillis` | 1000
+`fairness.urlCheck.readTimeoutMillis` | 2000
+
+Status responses retain endpoint, cache-use, success, and timing metadata but do not echo API keys or query strings. The documented `sync` parameter remains supported and continues to bypass the cache.
+
 ### 5- Deploy the war file in the Tomcat server
 Simply drop the war file into the *$CATALINA_HOME\webapps* directory of any Tomcat instance. If the instance is running, the deployment will start instantly as Tomcat unpacks the archive and configures its context path. If the instance is not running, then the server will deploy the project the next time it is started.
 

--- a/src/main/java/fr/lirmm/fairness/assessment/CacheHealthCMD.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/CacheHealthCMD.java
@@ -1,0 +1,20 @@
+package fr.lirmm.fairness.assessment;
+
+import fr.lirmm.fairness.assessment.models.Configuration;
+import fr.lirmm.fairness.assessment.utils.ResultCache;
+
+import java.util.Arrays;
+
+public class CacheHealthCMD {
+
+    public static void main(String[] args) {
+        System.exit(run(args, new ResultCache(), Configuration.getInstance().getConfiguredPortalAvailable()));
+    }
+
+    static int run(String[] args, ResultCache resultCache, String[] configuredPortals) {
+        if (args.length != 1 || configuredPortals == null || !Arrays.asList(configuredPortals).contains(args[0])) {
+            return 1;
+        }
+        return resultCache.isValid(args[0]) ? 0 : 1;
+    }
+}

--- a/src/main/java/fr/lirmm/fairness/assessment/CacheSaverCMD.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/CacheSaverCMD.java
@@ -19,7 +19,6 @@ public class CacheSaverCMD {
 
         for (String portal : args) {
             LOGGER.info("Cache saver for : " + portal);
-            resultCache.flush(portal);
             resultCache.save(PortalInstance.getFromConfiguration(Configuration.getInstance() , portal, true));
         }
     }

--- a/src/main/java/fr/lirmm/fairness/assessment/FairServlet.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/FairServlet.java
@@ -46,7 +46,7 @@ public class FairServlet extends HttpServlet {
             JsonObject ontologies = null;
             portalInstance = requestController.getPortalInstance();
 
-            LOGGER.info("USE THE PORTAL : " + portalInstance.getName() + "; url= " + portalInstance.getUrl() + "; apikey= " + portalInstance.getApikey());
+            LOGGER.info("USE THE PORTAL : " + portalInstance.getName() + "; url= " + portalInstance.getUrl().split("\\?", 2)[0]);
             List<String> ontologyAcronymsToEvaluate = requestController.getOntologies();
 
             LOGGER.info("START EVALUATION OF : " + ontologyAcronymsToEvaluate.size() + " ONTOLOGIES FROM " + portalInstance.getName().toUpperCase(Locale.ROOT));

--- a/src/main/java/fr/lirmm/fairness/assessment/controllers/RequestController.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/controllers/RequestController.java
@@ -39,7 +39,7 @@ public class RequestController {
         try{
             allOntologyAcronyms = getPortalInstance().getAllOntologiesAcronyms();
         } catch (Exception e){
-            throw new Exception("Portal " +getPortalInstance().getUrl() + " is not accessible : " + e.getMessage() +", You must provide a valid API Key");
+            throw new Exception("Portal " + getPortalInstance().getName() + " is not accessible; provide a valid API key");
         }
 
         if (pOntologies != null && pOntologies.equals("all")) {
@@ -71,12 +71,10 @@ public class RequestController {
 
     public String getRequestURI(HttpServletRequest request) {
 
-        return  request.getScheme() + "://" +
+        return request.getScheme() + "://" +
                 request.getServerName() +
                 ":" + request.getServerPort() +
-                request.getRequestURI() +
-                (request.getQueryString() != null ? "?" +
-                        request.getQueryString() : "");
+                request.getRequestURI();
     }
 
     public boolean isCombinedParamUsed() {

--- a/src/main/java/fr/lirmm/fairness/assessment/controllers/ResponseController.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/controllers/ResponseController.java
@@ -35,19 +35,19 @@ public class ResponseController {
 
         if(requestController.getPortalInstanceController().getPortalInstanceValue()!=null){
             PortalInstance portalInstance = requestController.getPortalInstanceController().getPortalInstanceValue();
-            jsonObject.add("endpoint", gson.toJsonTree(portalInstance.getUrl()));
-
-            if(!portalInstance.isPrivateAPI()){
-                jsonObject.add("apikey", gson.toJsonTree(portalInstance.getApikey()));
-            }
+            jsonObject.add("endpoint", gson.toJsonTree(withoutQuery(portalInstance.getUrl())));
             try {
                 jsonObject.add("useCache", gson.toJsonTree(!requestController.isCacheDisabled()));
             } catch (Exception ignored) {}
         }else {
-            jsonObject.add("endpoint", gson.toJsonTree(requestController.getParamController().portalUrl.getValue()));
+            jsonObject.add("endpoint", gson.toJsonTree(withoutQuery(requestController.getParamController().portalUrl.getValue())));
         }
 
         return jsonObject;
+    }
+
+    private static String withoutQuery(String endpoint) {
+        return endpoint == null ? null : endpoint.split("\\?", 2)[0];
     }
 
     public void respond(boolean success , String requestURI , long startTime, String message , RequestController requestController) throws Exception {

--- a/src/main/java/fr/lirmm/fairness/assessment/models/Ontology.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/models/Ontology.java
@@ -164,7 +164,7 @@ public class Ontology {
 			return OntologyRestApi.get(getMetaDataURL(), this.portalInstance.getApikey(), format);
 		}
 		catch (Exception e){
-			throw new Exception("Portal " +getPortalInstance().getUrl() + " is not accessible : " + getMetaDataURL() +" "+ e.getMessage());
+			throw new Exception("Portal " + getPortalInstance().getName() + " ontology metadata is not accessible");
 		}
 	}
 

--- a/src/main/java/fr/lirmm/fairness/assessment/principles/criterion/AbstractPrincipleCriterion.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/principles/criterion/AbstractPrincipleCriterion.java
@@ -41,7 +41,7 @@ public abstract class AbstractPrincipleCriterion extends AbstractScoredEntity im
 	public final void evaluate(Ontology ontology) throws JSONException, IOException {
 		this.results = new ArrayList<>();
 		if (LOGGER.isLoggable(Level.FINE)) {
-			LOGGER.fine("> Evaluating '" + this.getClass().getSimpleName() + "' of ontology '" + ontology.getAcronym() + "' on repository '" + ontology.getPortalInstance().getName() + "' (" + ontology.getPortalInstance().getUrl() + "?apikey=" + ontology.getPortalInstance().getApikey() + ").");
+			LOGGER.fine("> Evaluating '" + this.getClass().getSimpleName() + "' of ontology '" + ontology.getAcronym() + "' on repository '" + ontology.getPortalInstance().getName() + "'.");
 		}
 		this.doEvaluation(ontology);
 		this.scores = this.results.stream().map(x -> x.getScore()).collect(Collectors.toList());

--- a/src/main/java/fr/lirmm/fairness/assessment/principles/criterion/question/tests/ResolvableURLTest.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/principles/criterion/question/tests/ResolvableURLTest.java
@@ -21,7 +21,7 @@ public class ResolvableURLTest implements Test<String> {
         try {
             url = new URL(element[0]);
             urlConnection = (HttpURLConnection) url.openConnection();
-            HttpURLConnection.setFollowRedirects(false);
+            urlConnection.setInstanceFollowRedirects(false);
             urlConnection.setRequestMethod("HEAD");
 
             if(element.length == 3 && element[2]!= null && !element[2].isEmpty()){
@@ -34,7 +34,8 @@ public class ResolvableURLTest implements Test<String> {
             }
 
 
-            urlConnection.setConnectTimeout(1000); // 1 second
+            urlConnection.setConnectTimeout(positiveProperty("fairness.urlCheck.connectTimeoutMillis", 1000));
+            urlConnection.setReadTimeout(positiveProperty("fairness.urlCheck.readTimeoutMillis", 2000));
             int urlConnectionResponseCode = urlConnection.getResponseCode();
             boolean goodUrlContentType = urlConnection.getContentType() != null;
 
@@ -53,6 +54,11 @@ public class ResolvableURLTest implements Test<String> {
 
     }
 
+
+    private static int positiveProperty(String name, int defaultValue) {
+        Integer value = Integer.getInteger(name);
+        return value != null && value > 0 ? value : defaultValue;
+    }
 
     private static ResolvableURLTest getInstance() {
         if(instance == null){

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/OntologyRestApi.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/OntologyRestApi.java
@@ -132,28 +132,33 @@ public class OntologyRestApi {
 	}
 
 	public static String get(String urlToGet, String api_key, String format) throws Exception {
-		URL url;
-		HttpURLConnection conn;
-		String line;
-		StringBuilder result = new StringBuilder();
-		BufferedReader rd = null;
-		url = new URL(urlToGet);
-		conn = (HttpURLConnection) url.openConnection();
-		conn.setRequestMethod("GET");
-		conn.setRequestProperty("Authorization", "apikey token=" + api_key);
-		conn.setRequestProperty("Accept", format);
-		int response = conn.getResponseCode();
+		HttpURLConnection conn = (HttpURLConnection) new URL(urlToGet).openConnection();
+		try {
+			conn.setRequestMethod("GET");
+			conn.setRequestProperty("Authorization", "apikey token=" + api_key);
+			conn.setRequestProperty("Accept", format);
+			conn.setConnectTimeout(positiveProperty("fairness.http.connectTimeoutMillis", 10000));
+			conn.setReadTimeout(positiveProperty("fairness.http.readTimeoutMillis", 30000));
+			if (conn.getResponseCode() != 200) {
+				throw new Exception(conn.getResponseMessage());
+			}
 
-		if (response != 200) {
-			throw new Exception(conn.getResponseMessage());
+			StringBuilder result = new StringBuilder();
+			try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+				String line;
+				while ((line = reader.readLine()) != null) {
+					result.append(line);
+				}
+			}
+			return result.toString();
+		} finally {
+			conn.disconnect();
 		}
+	}
 
-		rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-		while ((line = rd.readLine()) != null) {
-			result.append(line);
-		}
-		rd.close();
-		return result.toString();
+	private static int positiveProperty(String name, int defaultValue) {
+		Integer value = Integer.getInteger(name);
+		return value != null && value > 0 ? value : defaultValue;
 	}
 
 }

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
@@ -1,18 +1,26 @@
 package fr.lirmm.fairness.assessment.utils;
 
 import com.google.gson.*;
-import fr.lirmm.fairness.assessment.models.Configuration;
 import fr.lirmm.fairness.assessment.Fair;
+import fr.lirmm.fairness.assessment.models.Configuration;
 import fr.lirmm.fairness.assessment.models.Ontology;
 import fr.lirmm.fairness.assessment.models.PortalInstance;
 import fr.lirmm.fairness.assessment.views.FairJsonConverter;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
 
 public class ResultCache {
 
@@ -20,8 +28,7 @@ public class ResultCache {
 
     public static String FILE_SAVE_NAME = "save.json";
 
-
-    public  void save(PortalInstance portalInstance){
+    public void save(PortalInstance portalInstance) {
         try {
             ResultCache resultCache = new ResultCache();
             String portal = portalInstance.getName();
@@ -30,7 +37,6 @@ public class ResultCache {
             Gson gson = new GsonBuilder().create();
             JsonObject output = new JsonObject();
             JsonObject jsonObjects = new JsonObject();
-
 
             Iterator<String> it = allOntologyAcronyms.iterator();
             int total = allOntologyAcronyms.size();
@@ -51,7 +57,7 @@ public class ResultCache {
             output.add("ontologies", gson.toJsonTree(jsonObjects));
 
             getFileSaveName(portal);
-            resultCache.store(output.toString() , FILE_SAVE_NAME);
+            resultCache.store(output.toString(), Paths.get(FILE_SAVE_NAME), total);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to save cache for " + portalInstance.getName(), e);
         }
@@ -59,51 +65,77 @@ public class ResultCache {
 
     public JsonObject read(PortalInstance portalInstance) throws IOException {
         String portal = portalInstance.getName();
-        if (!this.isSaved(portal)){
+        if (!this.isSaved(portal)) {
             throw new IOException("Cache not yet generated for portal '" + portal + "'. Run cache_reset.sh or wait for the next cron run.");
         }
         Gson gson = new GsonBuilder().create();
-
-        return gson.fromJson(this.get(FILE_SAVE_NAME) , JsonObject.class);
-
+        return gson.fromJson(this.get(FILE_SAVE_NAME), JsonObject.class);
     }
 
-    public boolean isSaved(String portal){
+    public boolean isSaved(String portal) {
         getFileSaveName(portal);
         File f = new File(FILE_SAVE_NAME);
         return (f.exists() && !f.isDirectory());
     }
+
+    public boolean isValid(String portal) {
+        try {
+            return isValid(Paths.get(getFileSaveName(portal)));
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    boolean isValid(Path path) {
+        return ontologyCount(path) > 0;
+    }
+
+    private boolean isValid(Path path, int sourceCount) {
+        return sourceCount > 0 && ontologyCount(path) == sourceCount;
+    }
+
+    private int ontologyCount(Path path) {
+        if (!Files.isRegularFile(path)) {
+            return -1;
+        }
+        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            JsonElement root = new JsonParser().parse(reader);
+            if (!root.isJsonObject()) {
+                return -1;
+            }
+            JsonElement ontologies = root.getAsJsonObject().get("ontologies");
+            return ontologies != null && ontologies.isJsonObject() ? ontologies.getAsJsonObject().size() : -1;
+        } catch (IOException | JsonParseException | IllegalStateException e) {
+            return -1;
+        }
+    }
+
     public void flush(String portal) {
         getFileSaveName(portal);
         File f = new File(FILE_SAVE_NAME);
         f.delete();
     }
 
-    private void store(String json, String fileName) throws IOException {
-        FileWriter file = null;
+    void store(String json, Path destination, int sourceCount) throws IOException {
+        Path absoluteDestination = destination.toAbsolutePath();
+        Path directory = absoluteDestination.getParent();
+        Files.createDirectories(directory);
+        Path temp = Files.createTempFile(directory, absoluteDestination.getFileName() + ".", ".tmp");
         try {
-
-            this.createDirIfNotExist(fileName);
-            file = new FileWriter(fileName);
-            file.write(json);
-
-        } finally {
-            try {
-                if(file != null){
-                    file.flush();
-                    file.close();
+            ByteBuffer bytes = StandardCharsets.UTF_8.encode(json);
+            try (FileChannel channel = FileChannel.open(temp, WRITE)) {
+                while (bytes.hasRemaining()) {
+                    channel.write(bytes);
                 }
-            } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "Failed to close cache writer", e);
+                channel.force(true);
             }
+            if (!isValid(temp, sourceCount)) {
+                throw new IOException("Refusing to publish an incomplete or invalid cache");
+            }
+            Files.move(temp, absoluteDestination, ATOMIC_MOVE, REPLACE_EXISTING);
+        } finally {
+            Files.deleteIfExists(temp);
         }
-    }
-
-    private boolean createDirIfNotExist(String filePath){
-        String dirPath = filePath.substring(0, filePath.lastIndexOf(File.separator));
-        File file = new File(dirPath);
-
-        return file.mkdir();
     }
 
     private String get(String filePath) throws IOException {
@@ -117,13 +149,13 @@ public class ResultCache {
                 sb.append(System.lineSeparator());
                 line = br.readLine();
             }
-            return  sb.toString();
+            return sb.toString();
         } finally {
             br.close();
         }
     }
 
-    private String getFileSaveName(String portal)  {
+    private String getFileSaveName(String portal) {
         try {
             FILE_SAVE_NAME = Configuration.getInstance().getPortalProperties(portal.toLowerCase(Locale.ROOT)).getProperty("cacheFilePath");
         } catch (IOException e) {

--- a/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
+++ b/src/main/java/fr/lirmm/fairness/assessment/utils/ResultCache.java
@@ -12,9 +12,15 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -80,8 +86,9 @@ public class ResultCache {
 
     public boolean isValid(String portal) {
         try {
-            return isValid(Paths.get(getFileSaveName(portal)));
-        } catch (RuntimeException e) {
+            String path = Configuration.getInstance().getPortalProperties(portal.toLowerCase(Locale.ROOT)).getProperty("cacheFilePath");
+            return path != null && isValid(Paths.get(path));
+        } catch (IOException | RuntimeException e) {
             return false;
         }
     }
@@ -120,7 +127,9 @@ public class ResultCache {
         Path absoluteDestination = destination.toAbsolutePath();
         Path directory = absoluteDestination.getParent();
         Files.createDirectories(directory);
-        Path temp = Files.createTempFile(directory, absoluteDestination.getFileName() + ".", ".tmp");
+        boolean posix = Files.getFileStore(directory).supportsFileAttributeView(PosixFileAttributeView.class);
+        PosixFileAttributes destinationAttributes = posix ? readAttributesIfExists(absoluteDestination) : null;
+        Path temp = createCandidate(directory, absoluteDestination, posix && destinationAttributes == null);
         try {
             ByteBuffer bytes = StandardCharsets.UTF_8.encode(json);
             try (FileChannel channel = FileChannel.open(temp, WRITE)) {
@@ -132,10 +141,57 @@ public class ResultCache {
             if (!isValid(temp, sourceCount)) {
                 throw new IOException("Refusing to publish an incomplete or invalid cache");
             }
+            if (destinationAttributes != null) {
+                preserveAttributes(temp, destinationAttributes);
+            }
             Files.move(temp, absoluteDestination, ATOMIC_MOVE, REPLACE_EXISTING);
         } finally {
             Files.deleteIfExists(temp);
         }
+    }
+
+    private PosixFileAttributes readAttributesIfExists(Path destination) throws IOException {
+        try {
+            return Files.readAttributes(destination, PosixFileAttributes.class);
+        } catch (NoSuchFileException e) {
+            if (Files.exists(destination, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Cannot read existing cache attributes", e);
+            }
+            return null;
+        } catch (UnsupportedOperationException | SecurityException e) {
+            throw new IOException("Cannot read existing cache attributes", e);
+        }
+    }
+
+    private void preserveAttributes(Path candidate, PosixFileAttributes expected) throws IOException {
+        try {
+            PosixFileAttributeView view = Files.getFileAttributeView(candidate, PosixFileAttributeView.class);
+            if (view == null) {
+                throw new IOException("Cannot preserve existing cache attributes");
+            }
+            view.setOwner(expected.owner());
+            view.setGroup(expected.group());
+            view.setPermissions(expected.permissions());
+            PosixFileAttributes actual = view.readAttributes();
+            if (!expected.owner().equals(actual.owner()) || !expected.group().equals(actual.group())
+                    || !expected.permissions().equals(actual.permissions())) {
+                throw new IOException("Cannot verify preserved cache attributes");
+            }
+        } catch (UnsupportedOperationException | SecurityException e) {
+            throw new IOException("Cannot preserve existing cache attributes", e);
+        }
+    }
+
+    private Path createCandidate(Path directory, Path destination, boolean readableDefault) throws IOException {
+        String prefix = destination.getFileName() + ".";
+        if (!readableDefault) {
+            return Files.createTempFile(directory, prefix, ".tmp");
+        }
+
+        // FileWriter previously created cache files as 0666 subject to the process umask.
+        FileAttribute<Set<PosixFilePermission>> permissions =
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-rw-rw-"));
+        return Files.createTempFile(directory, prefix, ".tmp", permissions);
     }
 
     private String get(String filePath) throws IOException {

--- a/src/test/java/fr/lirmm/fairness/assessment/CacheHealthCMDTest.java
+++ b/src/test/java/fr/lirmm/fairness/assessment/CacheHealthCMDTest.java
@@ -1,0 +1,64 @@
+package fr.lirmm.fairness.assessment;
+
+import fr.lirmm.fairness.assessment.utils.ResultCache;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CacheHealthCMDTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void validatesCacheStructure() throws Exception {
+        Path cache = temporaryFolder.getRoot().toPath().resolve("cache.json");
+        ResultCache resultCache = new ResultCache();
+
+        assertFalse(valid(resultCache, cache));
+        assertFalse(writeAndValidate(resultCache, cache, "bad json"));
+        assertFalse(writeAndValidate(resultCache, cache, "[]"));
+        assertFalse(writeAndValidate(resultCache, cache, "{\"other\":{}}"));
+        assertFalse(writeAndValidate(resultCache, cache, "{\"ontologies\":{}}"));
+        assertTrue(writeAndValidate(resultCache, cache, "{\"ontologies\":{\"A\":{}}}"));
+    }
+
+    @Test
+    public void runReturnsExactHealthExitCodes() {
+        String[] configured = {"portal"};
+        assertEquals(1, CacheHealthCMD.run(new String[0], cache(true), configured));
+        assertEquals(1, CacheHealthCMD.run(new String[]{"portal"}, cache(true), null));
+        assertEquals(1, CacheHealthCMD.run(new String[]{"portal", "extra"}, cache(true), configured));
+        assertEquals(1, CacheHealthCMD.run(new String[]{"unknown"}, cache(true), configured));
+        assertEquals(1, CacheHealthCMD.run(new String[]{"portal"}, cache(false), configured));
+        assertEquals(0, CacheHealthCMD.run(new String[]{"portal"}, cache(true), configured));
+    }
+
+    private ResultCache cache(boolean healthy) {
+        return new ResultCache() {
+            @Override
+            public boolean isValid(String portal) {
+                return healthy;
+            }
+        };
+    }
+
+    private boolean writeAndValidate(ResultCache resultCache, Path path, String json) throws Exception {
+        Files.write(path, json.getBytes(StandardCharsets.UTF_8));
+        return valid(resultCache, path);
+    }
+
+    private boolean valid(ResultCache resultCache, Path path) throws Exception {
+        java.lang.reflect.Method method = ResultCache.class.getDeclaredMethod("isValid", Path.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(resultCache, path);
+    }
+}

--- a/src/test/java/fr/lirmm/fairness/assessment/controllers/RequestResponseSecurityTest.java
+++ b/src/test/java/fr/lirmm/fairness/assessment/controllers/RequestResponseSecurityTest.java
@@ -1,0 +1,84 @@
+package fr.lirmm.fairness.assessment.controllers;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class RequestResponseSecurityTest {
+
+    @Test
+    public void statusDoesNotReflectSecretsOrQueriesAndSyncStillDisablesCache() throws Exception {
+        String apiSecret = "api-secret-7f3";
+        String querySecret = "request-secret-91a";
+        String endpointSecret = "endpoint-secret-55c";
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("url", "http://example.org/api?token=" + endpointSecret);
+        parameters.put("apikey", apiSecret);
+        parameters.put("sync", "");
+        HttpServletRequest request = request(parameters, querySecret);
+        StringWriter body = new StringWriter();
+
+        RequestController requestController = new RequestController(request);
+        requestController.getPortalInstance();
+        assertTrue(requestController.isCacheDisabled());
+        assertEquals("http://service.test:8080/ofaire", requestController.getRequestURI(request));
+
+        new ResponseController(response(body)).respond(true,
+                requestController.getRequestURI(request), System.currentTimeMillis(), "", requestController);
+
+        String json = body.toString();
+        assertFalse(json.contains(apiSecret));
+        assertFalse(json.contains(querySecret));
+        assertFalse(json.contains(endpointSecret));
+        JsonObject status = new JsonParser().parse(json).getAsJsonObject().getAsJsonObject("status");
+        assertFalse(status.has("apikey"));
+        assertFalse(status.get("request").getAsString().contains("?"));
+        assertFalse(status.get("endpoint").getAsString().contains("?"));
+        assertTrue(status.get("useCache").isJsonPrimitive());
+        assertFalse(status.get("useCache").getAsBoolean());
+    }
+
+    private HttpServletRequest request(Map<String, String> parameters, String querySecret) {
+        return (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class[]{HttpServletRequest.class}, (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getParameter": return parameters.get(args[0]);
+                        case "getScheme": return "http";
+                        case "getServerName": return "service.test";
+                        case "getServerPort": return 8080;
+                        case "getRequestURI": return "/ofaire";
+                        case "getQueryString": return "apikey=" + querySecret;
+                        default: return defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private HttpServletResponse response(StringWriter body) {
+        PrintWriter writer = new PrintWriter(body);
+        return (HttpServletResponse) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class[]{HttpServletResponse.class}, (proxy, method, args) ->
+                        method.getName().equals("getWriter") ? writer : defaultValue(method.getReturnType()));
+    }
+
+    private Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == char.class) return '\0';
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        return 0D;
+    }
+}

--- a/src/test/java/fr/lirmm/fairness/assessment/controllers/RequestResponseSecurityTest.java
+++ b/src/test/java/fr/lirmm/fairness/assessment/controllers/RequestResponseSecurityTest.java
@@ -2,6 +2,8 @@ package fr.lirmm.fairness.assessment.controllers;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpServer;
+import fr.lirmm.fairness.assessment.FairServlet;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
@@ -9,8 +11,13 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.*;
 
@@ -48,11 +55,53 @@ public class RequestResponseSecurityTest {
         assertFalse(status.get("useCache").getAsBoolean());
     }
 
+    @Test
+    public void servletLogsAndResponseDoNotContainRequestCredentials() throws Exception {
+        String secret = "logged-secret-2ce";
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/ontologies", exchange -> {
+            byte[] body = "[]".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        StringBuilder logs = new StringBuilder();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logs.append(record.getMessage());
+                if (record.getThrown() != null) logs.append(record.getThrown());
+            }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        Logger logger = Logger.getLogger(FairServlet.class.getName());
+        logger.addHandler(handler);
+        StringWriter responseBody = new StringWriter();
+        try {
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put("url", "http://127.0.0.1:" + server.getAddress().getPort());
+            parameters.put("apikey", secret);
+            parameters.put("ontologies", "all");
+            parameters.put("sync", "");
+            new FairServlet().service(request(parameters, secret), response(responseBody));
+        } finally {
+            logger.removeHandler(handler);
+            server.stop(0);
+        }
+
+        assertFalse(logs.toString().contains(secret));
+        assertFalse(responseBody.toString().contains(secret));
+    }
+
     private HttpServletRequest request(Map<String, String> parameters, String querySecret) {
         return (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(),
                 new Class[]{HttpServletRequest.class}, (proxy, method, args) -> {
                     switch (method.getName()) {
                         case "getParameter": return parameters.get(args[0]);
+                        case "getMethod": return "GET";
                         case "getScheme": return "http";
                         case "getServerName": return "service.test";
                         case "getServerPort": return 8080;

--- a/src/test/java/fr/lirmm/fairness/assessment/utils/HttpTimeoutTest.java
+++ b/src/test/java/fr/lirmm/fairness/assessment/utils/HttpTimeoutTest.java
@@ -1,0 +1,103 @@
+package fr.lirmm.fairness.assessment.utils;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import fr.lirmm.fairness.assessment.principles.criterion.question.tests.ResolvableURLTest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class HttpTimeoutTest {
+
+    private static HttpServer server;
+    private static String baseUrl;
+
+    @BeforeClass
+    public static void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/fast", exchange -> respond(exchange, 200, "ok"));
+        server.createContext("/error", exchange -> respond(exchange, 503, "no"));
+        server.createContext("/slow", exchange -> {
+            try {
+                Thread.sleep(500);
+                respond(exchange, 200, "late");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException ignored) {
+                exchange.close();
+            }
+        });
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        server.stop(0);
+    }
+
+    @After
+    public void clearProperties() {
+        System.clearProperty("fairness.http.connectTimeoutMillis");
+        System.clearProperty("fairness.http.readTimeoutMillis");
+        System.clearProperty("fairness.urlCheck.connectTimeoutMillis");
+        System.clearProperty("fairness.urlCheck.readTimeoutMillis");
+    }
+
+    @Test
+    public void fastApiEndpointSucceedsAndRepeatedRequestsDoNotExhaustConnections() throws Exception {
+        assertEquals("ok", OntologyRestApi.get(baseUrl + "/fast", "secret", "text/plain"));
+        for (int i = 0; i < 30; i++) {
+            assertEquals("ok", OntologyRestApi.get(baseUrl + "/fast", "secret", "text/plain"));
+            try {
+                OntologyRestApi.get(baseUrl + "/error", "secret", "text/plain");
+                fail("non-200 response should fail");
+            } catch (Exception expected) {
+                assertNotNull(expected.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void delayedApiReadIsBounded() {
+        System.setProperty("fairness.http.readTimeoutMillis", "100");
+        long start = System.nanoTime();
+        try {
+            OntologyRestApi.get(baseUrl + "/slow", "secret", "text/plain");
+            fail("delayed API should time out");
+        } catch (Exception expected) {
+            assertTrue(elapsedMillis(start) < 2000);
+        }
+    }
+
+    @Test
+    public void delayedResolvableUrlCheckIsBounded() {
+        System.setProperty("fairness.urlCheck.readTimeoutMillis", "100");
+        long start = System.nanoTime();
+        assertFalse(ResolvableURLTest.isValid(baseUrl + "/slow", "text/plain"));
+        assertTrue(elapsedMillis(start) < 2000);
+    }
+
+    private static long elapsedMillis(long start) {
+        return (System.nanoTime() - start) / 1_000_000;
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "text/plain");
+        if ("HEAD".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(status, -1);
+        } else {
+            exchange.sendResponseHeaders(status, bytes.length);
+            exchange.getResponseBody().write(bytes);
+        }
+        exchange.close();
+    }
+}

--- a/src/test/java/fr/lirmm/fairness/assessment/utils/ResultCachePublicationTest.java
+++ b/src/test/java/fr/lirmm/fairness/assessment/utils/ResultCachePublicationTest.java
@@ -1,0 +1,84 @@
+package fr.lirmm.fairness.assessment.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+public class ResultCachePublicationTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void invalidCandidatesPreserveOldBytesAndLeaveNoTemporaryFiles() throws Exception {
+        Path cache = cacheWith("{\"ontologies\":{\"old\":{}}}");
+        byte[] old = Files.readAllBytes(cache);
+
+        assertRejected(cache, "not json", 1, old);
+        assertRejected(cache, "[]", 1, old);
+        assertRejected(cache, "{\"other\":{}}", 1, old);
+        assertRejected(cache, "{\"ontologies\":{}}", 1, old);
+        assertRejected(cache, "{\"ontologies\":{\"only\":{}}}", 10, old);
+    }
+
+    @Test
+    public void completeCandidateReplacesOldCache() throws Exception {
+        Path cache = cacheWith("{\"ontologies\":{\"old\":{}}}");
+        String candidate = "{\"ontologies\":{\"one\":{},\"two\":{}}}";
+
+        new ResultCache().store(candidate, cache, 2);
+
+        assertEquals(candidate, new String(Files.readAllBytes(cache), StandardCharsets.UTF_8));
+        assertNoTemporaryFiles(cache);
+    }
+
+    @Test
+    public void legitimateCatalogueShrinkPublishesWhenCandidateMatchesSource() throws Exception {
+        Path cache = cacheWith(ontologies(10));
+        String candidate = ontologies(4);
+
+        new ResultCache().store(candidate, cache, 4);
+
+        assertEquals(candidate, new String(Files.readAllBytes(cache), StandardCharsets.UTF_8));
+        assertNoTemporaryFiles(cache);
+    }
+
+    private Path cacheWith(String content) throws IOException {
+        Path cache = temporaryFolder.getRoot().toPath().resolve("cache.json");
+        Files.write(cache, content.getBytes(StandardCharsets.UTF_8));
+        return cache;
+    }
+
+    private void assertRejected(Path cache, String candidate, int sourceCount, byte[] expected) throws Exception {
+        try {
+            new ResultCache().store(candidate, cache, sourceCount);
+            fail("invalid candidate was published");
+        } catch (IOException expectedFailure) {
+            assertArrayEquals(expected, Files.readAllBytes(cache));
+            assertNoTemporaryFiles(cache);
+        }
+    }
+
+    private void assertNoTemporaryFiles(Path cache) throws IOException {
+        try (Stream<Path> files = Files.list(cache.getParent())) {
+            assertEquals(1, files.count());
+        }
+    }
+
+    private String ontologies(int count) {
+        StringBuilder json = new StringBuilder("{\"ontologies\":{");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) json.append(',');
+            json.append('\"').append(i).append("\":{}");
+        }
+        return json.append("}}").toString();
+    }
+}

--- a/src/test/java/fr/lirmm/fairness/assessment/utils/ResultCachePublicationTest.java
+++ b/src/test/java/fr/lirmm/fairness/assessment/utils/ResultCachePublicationTest.java
@@ -8,6 +8,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
@@ -41,6 +47,52 @@ public class ResultCachePublicationTest {
     }
 
     @Test
+    public void atomicReplacementPreservesGroupReadableOwnershipAndPermissions() throws Exception {
+        Path cache = cacheWith("{\"ontologies\":{\"old\":{}}}");
+        org.junit.Assume.assumeTrue(supportsPosix(cache));
+        GroupPrincipal secondaryGroup = secondaryGroup(cache);
+        org.junit.Assume.assumeNotNull(secondaryGroup);
+        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-r-----");
+        PosixFileAttributeView view = Files.getFileAttributeView(cache, PosixFileAttributeView.class);
+        try {
+            view.setGroup(secondaryGroup);
+            view.setPermissions(permissions);
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            org.junit.Assume.assumeNoException(e);
+        }
+        PosixFileAttributes expected = view.readAttributes();
+
+        new ResultCache().store("{\"ontologies\":{\"new\":{}}}", cache, 1);
+
+        PosixFileAttributes actual = Files.readAttributes(cache, PosixFileAttributes.class);
+        assertEquals(expected.owner(), actual.owner());
+        assertEquals(secondaryGroup, actual.group());
+        assertEquals(permissions, actual.permissions());
+    }
+
+    @Test
+    public void deniedPublicationPreservesOldBytes() throws Exception {
+        Path cache = cacheWith("{\"ontologies\":{\"old\":{}}}");
+        org.junit.Assume.assumeTrue(supportsPosix(cache));
+        Path directory = cache.getParent();
+        byte[] old = Files.readAllBytes(cache);
+        Set<PosixFilePermission> directoryPermissions = Files.getPosixFilePermissions(directory);
+        try {
+            Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("r-x------"));
+            org.junit.Assume.assumeFalse(Files.isWritable(directory));
+            try {
+                new ResultCache().store("{\"ontologies\":{\"new\":{}}}", cache, 1);
+                fail("publication without directory write access succeeded");
+            } catch (IOException expected) {
+                assertArrayEquals(old, Files.readAllBytes(cache));
+                assertNoTemporaryFiles(cache);
+            }
+        } finally {
+            Files.setPosixFilePermissions(directory, directoryPermissions);
+        }
+    }
+
+    @Test
     public void legitimateCatalogueShrinkPublishesWhenCandidateMatchesSource() throws Exception {
         Path cache = cacheWith(ontologies(10));
         String candidate = ontologies(4);
@@ -58,13 +110,39 @@ public class ResultCachePublicationTest {
     }
 
     private void assertRejected(Path cache, String candidate, int sourceCount, byte[] expected) throws Exception {
+        Set<PosixFilePermission> permissions = supportsPosix(cache) ? Files.getPosixFilePermissions(cache) : null;
         try {
             new ResultCache().store(candidate, cache, sourceCount);
             fail("invalid candidate was published");
         } catch (IOException expectedFailure) {
             assertArrayEquals(expected, Files.readAllBytes(cache));
+            if (permissions != null) assertEquals(permissions, Files.getPosixFilePermissions(cache));
             assertNoTemporaryFiles(cache);
         }
+    }
+
+    private boolean supportsPosix(Path path) throws IOException {
+        return Files.getFileStore(path).supportsFileAttributeView(PosixFileAttributeView.class);
+    }
+
+    private GroupPrincipal secondaryGroup(Path path) {
+        try {
+            String primary = Files.readAttributes(path, PosixFileAttributes.class).group().getName();
+            Process process = new ProcessBuilder("id", "-Gn").start();
+            String groups = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            if (process.waitFor() == 0) {
+                for (String group : groups.trim().split("\\s+")) {
+                    if (!group.equals(primary)) {
+                        return path.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(group);
+                    }
+                }
+            }
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return null;
     }
 
     private void assertNoTemporaryFiles(Path cache) throws IOException {


### PR DESCRIPTION
### Summary

- Generate complete cache candidates before publishing them, validate a non-empty JSON object with an ontology count equal to the source catalogue, force candidate bytes to disk, and use an atomic same-directory replacement without a non-atomic fallback.
- Preserve an existing cache when evaluation, writing, validation, or atomic replacement fails. For an existing POSIX cache, copy and verify its owner, group, and permissions on the candidate before atomic replacement; if POSIX metadata cannot be read, set, or verified, refuse publication and leave the old cache untouched. For a new POSIX cache, retain the prior `0666` readable default filtered by the process umask, while leaving non-POSIX providers on their native defaults. Add `CacheHealthCMD <portal>` with exact `0` (healthy) / `1` (unhealthy or invalid invocation) status behavior.
- Add configurable positive connect/read timeouts and deterministic connection cleanup for API and resolvability HTTP calls.
- Stop returning API keys or query strings in status metadata and stop logging portal credentials. Public errors identify the portal without reflecting query-bearing metadata URLs.
- Keep the documented `sync` request behavior unchanged.

### Compatibility

`ResultCache.flush(String)` remains public for source compatibility. Cache generation remains all-or-nothing: a candidate publishes only when every source acronym has a result. Legitimate catalogue shrinkage still publishes when the complete candidate count matches the smaller source count.

### Test evidence

Base: `24def6b4b01fb7690e938adfc8477d6436c3cc1f`

Head: `cbe511dfd7bde4c8ba579ed3a5878eaec8d18765`

```text
$ /home/ranma/.local/tools/apache-maven-3.9.11/bin/mvn -B clean test
PASS — 12 tests, 0 failures, 0 errors, 0 skipped; Maven 3.932 s (wall 4.783 s)

$ /home/ranma/.local/tools/apache-maven-3.9.11/bin/mvn -B clean package
PASS — 12 tests, 0 failures, 0 errors, 0 skipped; Maven 6.677 s (wall 7.667 s)
WAR: target/fairness-assessment.war (8,545,701 bytes)

$ git diff --check
PASS

$ git diff --check origin/master...HEAD
PASS

$ git grep -nE 'apikey=.*getApikey|getQueryString|[?&]apikey=.*getApikey' -- src/main/java
PASS — no matches

$ git diff --name-only origin/master...HEAD
PASS — only the 15 documented README, Java, and JUnit files changed
```

Focused assertions cover:

- malformed, wrong-shape, empty, and `1/10` incomplete candidates preserving the old cache bytes and POSIX permissions exactly while leaving no temporary files;
- atomic replacement preserving an existing `0640` mode, owner, and an available supplementary group for cross-account readability; the test safely assumes/skips when POSIX group changes cannot be exercised;
- denied publication preserving old bytes with no temporary files left behind; the test safely assumes/skips where POSIX directory denial cannot be exercised;
- complete replacement and legitimate `10 -> 4` source/candidate shrink publication;
- missing/malformed/wrong-shape/empty/non-empty cache health and exact `0/1` command outcomes;
- API key, endpoint-query, and request-query secrets absent from serialized status and captured servlet logs, with `sync` still bypassing cache;
- fast local HTTP success, repeated success/error cleanup, and 500 ms delayed endpoints bounded by 100 ms test read timeouts (measured timeout cases: 0.096 s and 0.102 s, each below 2 s).

### Residual risks

- Filesystems without atomic-move support refuse refresh while preserving the old cache.
- Structural/count validation cannot detect semantically incorrect results or a consistently truncated source catalogue.
- `ResultCache.FILE_SAVE_NAME` remains mutable static state and may race during concurrent multi-portal work; changing that requires a separate compatibility refactor.
- `save()` retains the existing logging-and-swallowing failure contract; `CacheHealthCMD` proves structural health, not freshness.
- `FileChannel.force(true)` plus atomic rename does not portably fsync the parent directory.
- Status metadata intentionally loses API-key and query detail.
